### PR TITLE
Node 12 is not compatible with Sass 4.11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   web:
-    image: node
+    image: node:11.15.0
     volumes:
     - ./:/usr/src/app
     working_dir: /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
     - ./:/usr/src/app
     working_dir: /usr/src/app
-    command: sh -c "npm run install:all && npm run start:dev"
+    command: sh -c "npm install && npm run install:all && npm run build:client && npm run start:dev"
     depends_on:
     - mongo
     ports:


### PR DESCRIPTION
The `docker-compose.yml` is pulling the latest node version. This version is not compatible with the sass dependency and refuses to compile. This has been documented on the sass repo.

The fix is to fix the node image on docker.

Another option is to update sass to 4.12, maybe this should be up for discussion.

Also added the build command to the docker-compose file. The server requires some files to be found in the `./build` folder in order to run.

*Side note*:
[Based on git-flow](https://stackoverflow.com/questions/42229487/how-to-do-hotfixes-with-github-pull-requests), I'll be creating another PR to merge the hotfix onto the develop branch after this merges successfully. As such, please don't delete the branch.